### PR TITLE
altered product/option associations

### DIFF
--- a/server/db/index.js
+++ b/server/db/index.js
@@ -29,9 +29,10 @@ Product.Review = Product.hasMany(Review, { as: 'Reviews' });
 Product.Order = Product.belongsToMany(Order, { through: 'OrderProduct', as: 'LineItems' });
 Order.Product = Order.belongsToMany(Product, { through: 'OrderProduct', as: 'Orders' });
 
-Option.Base = Option.hasMany(Product, { as: 'BaseModels', foreignKey: 'baseId' });
-Option.Upgrade = Option.hasMany(Product, { as: 'Upgrades', foreignKey: 'upgradeId' });
+Option.Base = Option.belongsTo(Product, { as: 'BaseModels', foreignKey: 'baseId' });
+Option.Upgrade = Option.belongsTo(Product, { as: 'Upgrades', foreignKey: 'upgradeId' });
 
 Address.Order = Address.hasMany(Order, {as: 'Purchases'});
 
 module.exports = db;
+


### PR DESCRIPTION
#37 now allows two foreign keys in the options table (baseId and upgradeId) instead of just baseId
